### PR TITLE
Fix InfluxDB write bug

### DIFF
--- a/example/src/main/java/cn/edu/tsinghua/iginx/session/InfluxDBSessionExample.java
+++ b/example/src/main/java/cn/edu/tsinghua/iginx/session/InfluxDBSessionExample.java
@@ -39,7 +39,7 @@ public class InfluxDBSessionExample {
 	private static final String TS3 = "demo.census.portland.mullen.ants";
 	private static final String TS4 = "demo.census.portland.mullen.bees";
 
-	public static void main(String[] args) throws SessionException, ExecutionException, TTransportException, InterruptedException {
+	public static void main(String[] args) throws SessionException, ExecutionException, TTransportException {
 		session = new Session("127.0.0.1", 6324, "root", "root");
 		session.openSession();
 

--- a/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBPlanExecutor.java
+++ b/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBPlanExecutor.java
@@ -156,7 +156,11 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 		}
 
 		for (Map.Entry<Bucket, List<Point>> entry : bucketToPoints.entrySet()) {
-			client.getWriteApi().writePoints(entry.getKey().getId(), organization.getId(), entry.getValue());
+			if (plan.isSync()) {
+				client.getWriteApiBlocking().writePoints(entry.getKey().getId(), organization.getId(), entry.getValue());
+			} else {
+				client.getWriteApi().writePoints(entry.getKey().getId(), organization.getId(), entry.getValue());
+			}
 		}
 		return new NonDataPlanExecuteResult(SUCCESS, plan);
 	}


### PR DESCRIPTION
- 存在问题：数据后端为InfluxDB时，写入之后立刻查询有可能得不到正确结果。
- 解决方案：上述问题存在的原因是InfluxDB的java写入接口分为两类——WriteApi和WriteApiBlocking，前者是异步的，后者是同步的。因此同步写入的计划需要使用WriteApiBlocking，异步写入的需要使用WriteApi。