### PR TITLE
Fix aggregate bug

### DIFF
--- a/example/src/main/java/cn/edu/tsinghua/iginx/session/InfluxDBSessionExample.java
+++ b/example/src/main/java/cn/edu/tsinghua/iginx/session/InfluxDBSessionExample.java
@@ -23,7 +23,6 @@ import cn.edu.tsinghua.iginx.exceptions.SessionException;
 import cn.edu.tsinghua.iginx.thrift.AggregateType;
 import cn.edu.tsinghua.iginx.thrift.DataType;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.thrift.transport.TTransportException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +43,7 @@ public class InfluxDBSessionExample {
 	private static final long ROW_END_TIMESTAMP = 21000L;
 	private static final int ROW_INTERVAL = 10;
 
-	public static void main(String[] args) throws SessionException, ExecutionException, TTransportException {
+	public static void main(String[] args) throws SessionException, ExecutionException {
 		session = new Session("127.0.0.1", 6324, "root", "root");
 		// 打开 Session
 		session.openSession();
@@ -168,10 +167,51 @@ public class InfluxDBSessionExample {
 		dataSet.print();
 	}
 
+	private static void aggregateQuery() throws SessionException {
+		List<String> paths = new ArrayList<>();
+		paths.add(S1);
+		paths.add(S2);
+		paths.add(S3);
+		paths.add(S4);
+
+		long startTime = COLUMN_END_TIMESTAMP - 100L;
+		long endTime = ROW_START_TIMESTAMP + 100L;
+
+		// MAX
+		SessionAggregateQueryDataSet dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.MAX);
+		dataSet.print();
+
+		// MIN
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.MIN);
+		dataSet.print();
+
+		// FIRST
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.FIRST);
+		dataSet.print();
+
+		// LAST
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.LAST);
+		dataSet.print();
+
+		// COUNT
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.COUNT);
+		dataSet.print();
+
+		// SUM
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.SUM);
+		dataSet.print();
+
+		// AVG
+		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.AVG);
+		dataSet.print();
+	}
+
 	private static void downsampleQuery() throws SessionException {
 		List<String> paths = new ArrayList<>();
 		paths.add(S1);
 		paths.add(S2);
+		paths.add(S3);
+		paths.add(S4);
 
 		long startTime = ROW_START_TIMESTAMP;
 		long endTime = ROW_END_TIMESTAMP + 1;
@@ -208,43 +248,6 @@ public class InfluxDBSessionExample {
 
 		// 降采样查询结束
 		System.out.println("Downsample Query Finished.");
-	}
-
-	private static void aggregateQuery() throws SessionException {
-		List<String> paths = new ArrayList<>();
-		paths.add(S1);
-		paths.add(S2);
-
-		long startTime = COLUMN_END_TIMESTAMP - 100L;
-		long endTime = ROW_START_TIMESTAMP + 100L;
-
-		// MAX
-		SessionAggregateQueryDataSet dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.MAX);
-		dataSet.print();
-
-		// MIN
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.MIN);
-		dataSet.print();
-
-		// FIRST
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.FIRST);
-		dataSet.print();
-
-		// LAST
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.LAST);
-		dataSet.print();
-
-		// COUNT
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.COUNT);
-		dataSet.print();
-
-		// SUM
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.SUM);
-		dataSet.print();
-
-		// AVG
-		dataSet = session.aggregateQuery(paths, startTime, endTime, AggregateType.AVG);
-		dataSet.print();
 	}
 
 	private static void deleteDataInColumns() throws SessionException {

--- a/example/src/main/java/cn/edu/tsinghua/iginx/session/IoTDBSessionExample.java
+++ b/example/src/main/java/cn/edu/tsinghua/iginx/session/IoTDBSessionExample.java
@@ -23,7 +23,6 @@ import cn.edu.tsinghua.iginx.exceptions.SessionException;
 import cn.edu.tsinghua.iginx.thrift.AggregateType;
 import cn.edu.tsinghua.iginx.thrift.DataType;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.thrift.transport.TTransportException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +45,7 @@ public class IoTDBSessionExample {
 	private static final long ROW_END_TIMESTAMP = 21000L;
 	private static final int ROW_INTERVAL = 10;
 
-	public static void main(String[] args) throws SessionException, ExecutionException, TTransportException {
+	public static void main(String[] args) throws SessionException, ExecutionException {
 		session = new Session("127.0.0.1", 6324, "root", "root");
 		// 打开 Session
 		session.openSession();
@@ -55,12 +54,12 @@ public class IoTDBSessionExample {
 		session.createDatabase(DATABASE_NAME);
 
 		// 添加列
-	//	addColumns();
+		addColumns();
 		// 列式插入数据
-	//	insertColumnRecords();
+		insertColumnRecords();
 		// 行式插入数据
 		insertRowRecords();
-		valuefilterquery();
+		valueFilterQuery();
 		// 查询数据
 		queryData();
 		// 聚合查询数据
@@ -218,7 +217,7 @@ public class IoTDBSessionExample {
 		dataSet.print();
 	}
 
-	private static void valuefilterquery() throws SessionException {
+	private static void valueFilterQuery() throws SessionException {
 		List<String> paths = new ArrayList<>();
 		paths.add(S1);
 		paths.add(S2);
@@ -236,6 +235,8 @@ public class IoTDBSessionExample {
 		List<String> paths = new ArrayList<>();
 		paths.add(S1);
 		paths.add(S2);
+		paths.add(S3);
+		paths.add(S4);
 
 		long startTime = ROW_START_TIMESTAMP;
 		long endTime = ROW_END_TIMESTAMP + 1;
@@ -278,6 +279,8 @@ public class IoTDBSessionExample {
 		List<String> paths = new ArrayList<>();
 		paths.add(S1);
 		paths.add(S2);
+		paths.add(S3);
+		paths.add(S4);
 
 		long startTime = COLUMN_END_TIMESTAMP - 100L;
 		long endTime = ROW_START_TIMESTAMP + 100L;

--- a/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBPlanExecutor.java
+++ b/influxdb/src/main/java/cn/edu/tsinghua/iginx/influxdb/InfluxDBPlanExecutor.java
@@ -6,7 +6,22 @@ import cn.edu.tsinghua.iginx.exceptions.UnsupportedDataTypeException;
 import cn.edu.tsinghua.iginx.influxdb.query.entity.InfluxDBQueryExecuteDataSet;
 import cn.edu.tsinghua.iginx.metadata.StorageEngineChangeHook;
 import cn.edu.tsinghua.iginx.metadata.entity.StorageEngineMeta;
-import cn.edu.tsinghua.iginx.plan.*;
+import cn.edu.tsinghua.iginx.plan.AddColumnsPlan;
+import cn.edu.tsinghua.iginx.plan.AvgQueryPlan;
+import cn.edu.tsinghua.iginx.plan.CountQueryPlan;
+import cn.edu.tsinghua.iginx.plan.CreateDatabasePlan;
+import cn.edu.tsinghua.iginx.plan.DeleteColumnsPlan;
+import cn.edu.tsinghua.iginx.plan.DeleteDataInColumnsPlan;
+import cn.edu.tsinghua.iginx.plan.DropDatabasePlan;
+import cn.edu.tsinghua.iginx.plan.FirstQueryPlan;
+import cn.edu.tsinghua.iginx.plan.InsertColumnRecordsPlan;
+import cn.edu.tsinghua.iginx.plan.InsertRowRecordsPlan;
+import cn.edu.tsinghua.iginx.plan.LastQueryPlan;
+import cn.edu.tsinghua.iginx.plan.MaxQueryPlan;
+import cn.edu.tsinghua.iginx.plan.MinQueryPlan;
+import cn.edu.tsinghua.iginx.plan.QueryDataPlan;
+import cn.edu.tsinghua.iginx.plan.SumQueryPlan;
+import cn.edu.tsinghua.iginx.plan.ValueFilterQueryPlan;
 import cn.edu.tsinghua.iginx.plan.downsample.DownsampleAvgQueryPlan;
 import cn.edu.tsinghua.iginx.plan.downsample.DownsampleCountQueryPlan;
 import cn.edu.tsinghua.iginx.plan.downsample.DownsampleFirstQueryPlan;
@@ -17,7 +32,13 @@ import cn.edu.tsinghua.iginx.plan.downsample.DownsampleQueryPlan;
 import cn.edu.tsinghua.iginx.plan.downsample.DownsampleSumQueryPlan;
 import cn.edu.tsinghua.iginx.query.IStorageEngine;
 import cn.edu.tsinghua.iginx.query.entity.QueryExecuteDataSet;
-import cn.edu.tsinghua.iginx.query.result.*;
+import cn.edu.tsinghua.iginx.query.result.AvgAggregateQueryPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.DownsampleQueryPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.NonDataPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.QueryDataPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.SingleValueAggregateQueryPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.StatisticsAggregateQueryPlanExecuteResult;
+import cn.edu.tsinghua.iginx.query.result.ValueFilterQueryPlanExecuteResult;
 import cn.edu.tsinghua.iginx.thrift.DataType;
 import cn.edu.tsinghua.iginx.utils.Bitmap;
 import com.influxdb.client.InfluxDBClient;
@@ -43,6 +64,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static cn.edu.tsinghua.iginx.influxdb.tools.DataTypeTransformer.fromInfluxDB;
+import static cn.edu.tsinghua.iginx.query.result.PlanExecuteResult.FAILURE;
 import static cn.edu.tsinghua.iginx.query.result.PlanExecuteResult.SUCCESS;
 import static cn.edu.tsinghua.iginx.thrift.DataType.BINARY;
 import static cn.edu.tsinghua.iginx.thrift.DataType.LONG;
@@ -378,6 +400,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Long> counts = new ArrayList<>();
 		List<Object> sums = new ArrayList<>();
@@ -393,44 +416,53 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 
 			List<FluxTable> countTables;
 			List<FluxTable> sumTables;
-			if (value != null) {
-				countTables = client.getQueryApi().query(String.format(
-						COUNT_WITH_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field,
-						value
-				), organization.getId());
-				sumTables = client.getQueryApi().query(String.format(
-						SUM_WITH_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field,
-						value
-				), organization.getId());
-			} else {
-				countTables = client.getQueryApi().query(String.format(
-						COUNT_WITHOUT_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field
-				), organization.getId());
-				sumTables = client.getQueryApi().query(String.format(
-						SUM_WITHOUT_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field
-				), organization.getId());
+			try {
+				if (value != null) {
+					countTables = client.getQueryApi().query(String.format(
+							COUNT_WITH_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field,
+							value
+					), organization.getId());
+					sumTables = client.getQueryApi().query(String.format(
+							SUM_WITH_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field,
+							value
+					), organization.getId());
+				} else {
+					countTables = client.getQueryApi().query(String.format(
+							COUNT_WITHOUT_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field
+					), organization.getId());
+					sumTables = client.getQueryApi().query(String.format(
+							SUM_WITHOUT_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field
+					), organization.getId());
+				}
+			} catch (Exception e) {
+				if (e.getMessage().contains("unsupported input type for sum aggregate")) {
+					continue;
+				} else {
+					return new AvgAggregateQueryPlanExecuteResult(FAILURE, plan);
+				}
 			}
 
+			paths.add(path);
 			if (!countTables.isEmpty() && !sumTables.isEmpty()) {
 				dataTypeList.add(fromInfluxDB(sumTables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
 				counts.add((Long) countTables.get(0).getRecords().get(0).getValue());
@@ -443,7 +475,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 		}
 
 		AvgAggregateQueryPlanExecuteResult result = new AvgAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setDataTypes(dataTypeList);
 		result.setCounts(counts);
 		result.setSums(sums);
@@ -520,6 +552,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Object> values = new ArrayList<>();
 		for (String path : plan.getPaths()) {
@@ -533,27 +566,36 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 			}
 
 			List<FluxTable> tables;
-			if (value != null) {
-				tables = client.getQueryApi().query(String.format(
-						SUM_WITH_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field,
-						value
-				), organization.getId());
-			} else {
-				tables = client.getQueryApi().query(String.format(
-						SUM_WITHOUT_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field
-				), organization.getId());
+			try {
+				if (value != null) {
+					tables = client.getQueryApi().query(String.format(
+							SUM_WITH_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field,
+							value
+					), organization.getId());
+				} else {
+					tables = client.getQueryApi().query(String.format(
+							SUM_WITHOUT_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field
+					), organization.getId());
+				}
+			} catch (Exception e) {
+				if (e.getMessage().contains("unsupported input type for sum aggregate")) {
+					continue;
+				} else {
+					return new StatisticsAggregateQueryPlanExecuteResult(FAILURE, plan);
+				}
 			}
 
+			paths.add(path);
 			if (!tables.isEmpty()) {
 				dataTypeList.add(fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
 				values.add(tables.get(0).getRecords().get(0).getValue());
@@ -564,7 +606,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 		}
 
 		StatisticsAggregateQueryPlanExecuteResult result = new StatisticsAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setDataTypes(dataTypeList);
 		result.setValues(values);
 
@@ -580,6 +622,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Long> timestamps = new ArrayList<>();
 		List<Object> values = new ArrayList<>();
@@ -616,18 +659,20 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 			}
 
 			if (!tables.isEmpty()) {
-				dataTypeList.add(fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
+				paths.add(path);
+				DataType dataType = fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType());
+				dataTypeList.add(dataType);
 				timestamps.add(tables.get(0).getRecords().get(0).getTime().toEpochMilli());
-				values.add(tables.get(0).getRecords().get(0).getValue());
-			} else {
-				dataTypeList.add(BINARY);
-				timestamps.add(-1L);
-				values.add("null".getBytes());
+				if (dataType != BINARY) {
+					values.add(tables.get(0).getRecords().get(0).getValue());
+				} else {
+					values.add(((String) tables.get(0).getRecords().get(0).getValue()).getBytes());
+				}
 			}
 		}
 
 		SingleValueAggregateQueryPlanExecuteResult result = new SingleValueAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setTimes(timestamps);
 		result.setDataTypes(dataTypeList);
 		result.setValues(values);
@@ -644,6 +689,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Long> timestamps = new ArrayList<>();
 		List<Object> values = new ArrayList<>();
@@ -680,18 +726,20 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 			}
 
 			if (!tables.isEmpty()) {
-				dataTypeList.add(fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
+				paths.add(path);
+				DataType dataType = fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType());
+				dataTypeList.add(dataType);
 				timestamps.add(tables.get(0).getRecords().get(0).getTime().toEpochMilli());
-				values.add(tables.get(0).getRecords().get(0).getValue());
-			} else {
-				dataTypeList.add(BINARY);
-				timestamps.add(-1L);
-				values.add("null".getBytes());
+				if (dataType != BINARY) {
+					values.add(tables.get(0).getRecords().get(0).getValue());
+				} else {
+					values.add(((String) tables.get(0).getRecords().get(0).getValue()).getBytes());
+				}
 			}
 		}
 
 		SingleValueAggregateQueryPlanExecuteResult result = new SingleValueAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setTimes(timestamps);
 		result.setDataTypes(dataTypeList);
 		result.setValues(values);
@@ -708,6 +756,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Long> timestamps = new ArrayList<>();
 		List<Object> values = new ArrayList<>();
@@ -722,40 +771,46 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 			}
 
 			List<FluxTable> tables;
-			if (value != null) {
-				tables = client.getQueryApi().query(String.format(
-						MAX_WITH_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field,
-						value
-				), organization.getId());
-			} else {
-				tables = client.getQueryApi().query(String.format(
-						MAX_WITHOUT_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field
-				), organization.getId());
+			try {
+				if (value != null) {
+					tables = client.getQueryApi().query(String.format(
+							MAX_WITH_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field,
+							value
+					), organization.getId());
+				} else {
+					tables = client.getQueryApi().query(String.format(
+							MAX_WITHOUT_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field
+					), organization.getId());
+				}
+			} catch (Exception e) {
+				// TODO 字符串类型不支持 Max 和 Min
+				if (e.getMessage().contains("panic: unsupported for aggregate max")) {
+					continue;
+				} else {
+					return new SingleValueAggregateQueryPlanExecuteResult(FAILURE, plan);
+				}
 			}
 
 			if (!tables.isEmpty()) {
+				paths.add(path);
 				dataTypeList.add(fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
 				timestamps.add(tables.get(0).getRecords().get(0).getTime().toEpochMilli());
 				values.add(tables.get(0).getRecords().get(0).getValue());
-			} else {
-				dataTypeList.add(BINARY);
-				timestamps.add(-1L);
-				values.add("null".getBytes());
 			}
 		}
 
 		SingleValueAggregateQueryPlanExecuteResult result = new SingleValueAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setTimes(timestamps);
 		result.setDataTypes(dataTypeList);
 		result.setValues(values);
@@ -772,6 +827,7 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 				.findFirst()
 				.orElseThrow(IllegalStateException::new);
 
+		List<String> paths = new ArrayList<>();
 		List<DataType> dataTypeList = new ArrayList<>();
 		List<Long> timestamps = new ArrayList<>();
 		List<Object> values = new ArrayList<>();
@@ -786,40 +842,45 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 			}
 
 			List<FluxTable> tables;
-			if (value != null) {
-				tables = client.getQueryApi().query(String.format(
-						MIN_WITH_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field,
-						value
-				), organization.getId());
-			} else {
-				tables = client.getQueryApi().query(String.format(
-						MIN_WITHOUT_TAG,
-						bucketName,
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
-						ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
-						measurement,
-						field
-				), organization.getId());
+			try {
+				if (value != null) {
+					tables = client.getQueryApi().query(String.format(
+							MIN_WITH_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field,
+							value
+					), organization.getId());
+				} else {
+					tables = client.getQueryApi().query(String.format(
+							MIN_WITHOUT_TAG,
+							bucketName,
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getStartTime()), ZoneId.of("UTC")).format(FORMATTER),
+							ZonedDateTime.ofInstant(Instant.ofEpochMilli(plan.getEndTime()), ZoneId.of("UTC")).format(FORMATTER),
+							measurement,
+							field
+					), organization.getId());
+				}
+			} catch (Exception e) {
+				if (e.getMessage().contains("panic: unsupported for aggregate min")) {
+					continue;
+				} else {
+					return new SingleValueAggregateQueryPlanExecuteResult(FAILURE, plan);
+				}
 			}
 
 			if (!tables.isEmpty()) {
+				paths.add(path);
 				dataTypeList.add(fromInfluxDB(tables.get(0).getColumns().stream().filter(x -> x.getLabel().equals("_value")).collect(Collectors.toList()).get(0).getDataType()));
 				timestamps.add(tables.get(0).getRecords().get(0).getTime().toEpochMilli());
 				values.add(tables.get(0).getRecords().get(0).getValue());
-			} else {
-				dataTypeList.add(BINARY);
-				timestamps.add(-1L);
-				values.add("null".getBytes());
 			}
 		}
 
 		SingleValueAggregateQueryPlanExecuteResult result = new SingleValueAggregateQueryPlanExecuteResult(SUCCESS, plan);
-		result.setPaths(plan.getPaths());
+		result.setPaths(paths);
 		result.setTimes(timestamps);
 		result.setDataTypes(dataTypeList);
 		result.setValues(values);
@@ -941,7 +1002,18 @@ public class InfluxDBPlanExecutor implements IStorageEngine {
 					throw new UnsupportedOperationException(plan.getIginxPlanType().toString());
 			}
 
-			tables = client.getQueryApi().query(statement, organization.getId());
+			try {
+				tables = client.getQueryApi().query(statement, organization.getId());
+			} catch (Exception e) {
+				if (e.getMessage().contains("panic: unsupported for aggregate max")
+						|| e.getMessage().contains("panic: unsupported for aggregate min")
+						|| e.getMessage().contains("unsupported input type for sum aggregate")
+						|| e.getMessage().contains("unsupported input type for mean aggregate")) {
+					continue;
+				} else {
+					return new DownsampleQueryPlanExecuteResult(FAILURE, plan, null);
+				}
+			}
 
 			dataSets.addAll(tables.stream().map(x -> new InfluxDBQueryExecuteDataSet(bucketName, x)).collect(Collectors.toList()));
 		}


### PR DESCRIPTION
- 存在问题：对字符串类型的数据执行sum和avg类型的聚合查询会报错。
- 出现原因：字符串类型的数据本就不应该支持sum和avg操作，但IginX未进行异常处理。
- 解决方案：由于聚合查询请求中不包含数据类型，所以在将请求发给底层数据库之前，IginX无法得知该时间序列是否为字符串类型，只能等待捕获底层数据库返回的异常。现在的解决方案就是捕获到不支持该类型异常后，在返回结果集中不会出现该条时间序列。
- 特别说明：InfluxDB的max和min也不支持字符串类型。