### PR TITLE
Fix integration testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.7.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/IoTDBSessionDataTypeTest.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/IoTDBSessionDataTypeTest.java
@@ -7,10 +7,18 @@ import cn.edu.tsinghua.iginx.session.SessionAggregateQueryDataSet;
 import cn.edu.tsinghua.iginx.session.SessionQueryDataSet;
 import cn.edu.tsinghua.iginx.thrift.AggregateType;
 import cn.edu.tsinghua.iginx.thrift.DataType;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZKUtil;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,6 +32,7 @@ import static org.junit.Assert.fail;
 
 public class IoTDBSessionDataTypeTest {
 
+    private static final Logger logger = LoggerFactory.getLogger(IoTDBSessionDataTypeTest.class);
     private static final String DATABASE_NAME = "sg1";
     private static final String COLUMN_D1_S1 = "sg1.d1.s1";
     private static final String COLUMN_D2_S2 = "sg1.d2.s2";
@@ -152,8 +161,6 @@ public class IoTDBSessionDataTypeTest {
             session.createDatabase(DATABASE_NAME);
             addColumns();
             insertRecords();
-            //TODO remove this line when the new iotdb release version fix this bug
-            Thread.sleep(10000);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -161,8 +168,39 @@ public class IoTDBSessionDataTypeTest {
 
     @After
     public void tearDown() throws ExecutionException, SessionException {
-        session.dropDatabase(DATABASE_NAME);
-        session.closeSession();
+        // delete metadata from ZooKeeper
+        ZooKeeper zk = null;
+        try {
+            zk = new ZooKeeper("127.0.0.1:2181", 5000, null);
+            ZKUtil.deleteRecursive(zk, "/iginx");
+            ZKUtil.deleteRecursive(zk, "/storage");
+            ZKUtil.deleteRecursive(zk, "/unit");
+            ZKUtil.deleteRecursive(zk, "/lock");
+            ZKUtil.deleteRecursive(zk, "/fragment");
+        } catch (IOException | InterruptedException | KeeperException e) {
+            logger.error(e.getMessage());
+        }
+
+        // delete data from IoTDB
+        org.apache.iotdb.session.Session iotdbSession = null;
+        try {
+            iotdbSession = new org.apache.iotdb.session.Session("127.0.0.1", 6667, "root", "root");
+            iotdbSession.open(false);
+            iotdbSession.executeNonQueryStatement("DELETE TIMESERIES root.*");
+        } catch (IoTDBConnectionException | StatementExecutionException e) {
+            logger.error(e.getMessage());
+        }
+
+        // close session
+        try {
+            iotdbSession.close();
+            if (zk != null) {
+                zk.close();
+            }
+            session.closeSession();
+        } catch (InterruptedException | IoTDBConnectionException e) {
+            logger.error(e.getMessage());
+        }
     }
 
     @Test
@@ -170,32 +208,32 @@ public class IoTDBSessionDataTypeTest {
         SessionQueryDataSet dataSet = session.queryData(paths, START_TIME, END_TIME + 1);
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(resPaths.size(), 6);
-        assertEquals(len, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(6, resPaths.size());
+        assertEquals(TIME_PERIOD, len);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i);
+            assertEquals(i, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 6; j++) {
                 switch (resPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(result.get(j), (int) ((END_TIME - i) + 1 + START_TIME));
+                        assertEquals((int) ((END_TIME - i) + 1 + START_TIME), result.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(result.get(j), (i + 2 + START_TIME) * 1000);
+                        assertEquals((i + 2 + START_TIME) * 1000, result.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals((float) result.get(j), (float) (i + 3 + START_TIME + 0.01), (float) delta);
+                        assertEquals((float) (i + 3 + START_TIME + 0.01), (float) result.get(j), (float) delta);
                         break;
                     case "sg1.d4.s4":
-                        assertEquals((double) result.get(j), ((END_TIME - i) + 4 + START_TIME + 0.01) * 999, delta);
+                        assertEquals(((END_TIME - i) + 4 + START_TIME + 0.01) * 999, (double) result.get(j), delta);
                         break;
                     case "sg1.d5.s5":
-                        assertArrayEquals((byte[]) (result.get(j)), getRandomStr(i, STRING_LEN).getBytes());
+                        assertArrayEquals(getRandomStr(i, STRING_LEN).getBytes(), (byte[]) (result.get(j)));
                         break;
                     case "sg1.d0.s0":
-                        assertEquals(result.get(j), i % 2 == 0);
+                        assertEquals(i % 2 == 0, result.get(j));
                         break;
                     default:
                         fail();
@@ -218,21 +256,21 @@ public class IoTDBSessionDataTypeTest {
         SessionAggregateQueryDataSet maxDataSet = session.aggregateQuery(aggrPaths, START_TIME, END_TIME + 1, AggregateType.MAX);
         List<String> maxResPaths = maxDataSet.getPaths();
         Object[] maxResult = maxDataSet.getValues();
-        assertEquals(maxResPaths.size(), aggrPaths.size());
-        assertEquals(maxDataSet.getValues().length, aggrPaths.size());
+        assertEquals(aggrPaths.size(), maxResPaths.size());
+        assertEquals(aggrPaths.size(), maxDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             switch (maxResPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(maxResult[i], (int) (END_TIME + 1));
+                    assertEquals((int) (END_TIME + 1), maxResult[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(maxResult[i], (END_TIME + 2) * 1000);
+                    assertEquals((END_TIME + 2) * 1000, maxResult[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals((float) maxResult[i], (float) (END_TIME + 3 + 0.01), delta);
+                    assertEquals((float) (END_TIME + 3 + 0.01), (float) maxResult[i], delta);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals((double) maxResult[i], (END_TIME + 4 + 0.01) * 999, delta);
+                    assertEquals((END_TIME + 4 + 0.01) * 999, (double) maxResult[i], delta);
                     break;
                 default:
                     fail();
@@ -244,21 +282,21 @@ public class IoTDBSessionDataTypeTest {
         SessionAggregateQueryDataSet avgDataSet = session.aggregateQuery(aggrPaths, START_TIME, END_TIME + 1, AggregateType.AVG);
         List<String> avgResPaths = avgDataSet.getPaths();
         Object[] avgResult = avgDataSet.getValues();
-        assertEquals(avgResPaths.size(), aggrPaths.size());
-        assertEquals(avgDataSet.getValues().length, aggrPaths.size());
+        assertEquals(aggrPaths.size(), avgResPaths.size());
+        assertEquals(aggrPaths.size(), avgDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             switch (avgResPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals((double) avgResult[i], (START_TIME + END_TIME) / 2.0 + 1, delta);
+                    assertEquals((START_TIME + END_TIME) / 2.0 + 1, (double) avgResult[i], delta);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(avgResult[i], (START_TIME + END_TIME) * 500.0 + 2000);
+                    assertEquals((START_TIME + END_TIME) * 500.0 + 2000, avgResult[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals((double) avgResult[i], (START_TIME + END_TIME) / 2.0 + 3 + 0.01, delta * 1000);
+                    assertEquals((START_TIME + END_TIME) / 2.0 + 3 + 0.01, (double) avgResult[i], delta * 1000);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals((double) avgResult[i], (START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, delta * 1000);
+                    assertEquals((START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, (double) avgResult[i], delta * 1000);
                     break;
                 default:
                     fail();
@@ -268,7 +306,7 @@ public class IoTDBSessionDataTypeTest {
     }
 
     @Test
-    public void deletePartDataTest() throws SessionException, ExecutionException {
+    public void deletePartialDataTest() throws SessionException, ExecutionException {
         List<String> delPaths = new ArrayList<>();
         delPaths.add(COLUMN_D1_S1);
         delPaths.add(COLUMN_D3_S3);
@@ -286,42 +324,42 @@ public class IoTDBSessionDataTypeTest {
 
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(dataSet.getTimestamps().length, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(TIME_PERIOD, dataSet.getTimestamps().length);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 6; j++) {
                 switch (resPaths.get(j)) {
                     case "sg1.d0.s0":
-                        assertEquals(result.get(j), timestamp % 2 == 0);
+                        assertEquals(timestamp % 2 == 0, result.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(result.get(j), (timestamp + 2) * 1000);
+                        assertEquals((timestamp + 2) * 1000, result.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals((double) result.get(j), (4 + (END_TIME - timestamp) + 0.01) * 999, delta);
+                        assertEquals((4 + (END_TIME - timestamp) + 0.01) * 999, (double) result.get(j), delta);
                         break;
                     case "sg1.d1.s1":
                         if (delStartTime <= timestamp && timestamp <= delEndTime) {
                             assertNull(result.get(j));
                         } else {
-                            assertEquals(result.get(j), (int) ((END_TIME - i) + 1 + START_TIME));
+                            assertEquals((int) ((END_TIME - i) + 1 + START_TIME), result.get(j));
                         }
                         break;
                     case "sg1.d3.s3":
                         if (delStartTime <= timestamp && timestamp <= delEndTime) {
                             assertNull(result.get(j));
                         } else {
-                            assertEquals((float) result.get(j), (float) (i + 3 + START_TIME + 0.01), (float) delta);
+                            assertEquals((float) (i + 3 + START_TIME + 0.01), (float) result.get(j), (float) delta);
                         }
                         break;
                     case "sg1.d5.s5":
                         if (delStartTime <= timestamp && timestamp <= delEndTime) {
                             assertNull(result.get(j));
                         } else {
-                            assertArrayEquals((byte[]) (result.get(j)), getRandomStr(i, STRING_LEN).getBytes());
+                            assertArrayEquals(getRandomStr(i, STRING_LEN).getBytes(), (byte[]) (result.get(j)));
                         }
                         break;
                     default:
@@ -342,23 +380,23 @@ public class IoTDBSessionDataTypeTest {
         SessionAggregateQueryDataSet avgDataSet = session.aggregateQuery(aggrPaths, START_TIME, END_TIME + 1, AggregateType.AVG);
         List<String> avgResPaths = avgDataSet.getPaths();
         Object[] avgResult = avgDataSet.getValues();
-        assertEquals(avgResPaths.size(), aggrPaths.size());
-        assertEquals(avgDataSet.getValues().length, aggrPaths.size());
+        assertEquals(aggrPaths.size(), avgResPaths.size());
+        assertEquals(aggrPaths.size(), avgDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             switch (avgResPaths.get(i)) {
                 case "sg1.d2.s2":
-                    assertEquals(avgResult[i], (START_TIME + END_TIME) * 500.0 + 2000);
+                    assertEquals((START_TIME + END_TIME) * 500.0 + 2000, avgResult[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals((double) avgResult[i], (START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, delta * 1000);
+                    assertEquals((START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, (double) avgResult[i], delta * 1000);
                     break;
                 case "sg1.d1.s1":
-                    assertEquals((double) avgResult[i], ((START_TIME + END_TIME) * TIME_PERIOD / 2.0 -
-                            (END_TIME - delStartTime + END_TIME - delEndTime) * delTimePeriod / 2.0) / (TIME_PERIOD - delTimePeriod) + 1.0, delta * 1000);
+                    assertEquals(((START_TIME + END_TIME) * TIME_PERIOD / 2.0 -
+                            (END_TIME - delStartTime + END_TIME - delEndTime) * delTimePeriod / 2.0) / (TIME_PERIOD - delTimePeriod) + 1.0, (double) avgResult[i], delta * 1000);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals((double) avgResult[i], ((START_TIME + END_TIME) * TIME_PERIOD / 2.0 -
-                            (delStartTime + delEndTime) * delTimePeriod / 2.0) / (TIME_PERIOD - delTimePeriod) + 3.01, delta * 1000);
+                    assertEquals(((START_TIME + END_TIME) * TIME_PERIOD / 2.0 -
+                            (delStartTime + delEndTime) * delTimePeriod / 2.0) / (TIME_PERIOD - delTimePeriod) + 3.01, (double) avgResult[i], delta * 1000);
                     break;
                 default:
                     fail();
@@ -378,22 +416,22 @@ public class IoTDBSessionDataTypeTest {
         SessionQueryDataSet dataSet = session.queryData(paths, START_TIME, END_TIME + 1);
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(dataSet.getTimestamps().length, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(TIME_PERIOD, dataSet.getTimestamps().length);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 6; j++) {
                 switch (resPaths.get(j)) {
                     case "sg1.d0.s0":
-                        assertEquals(result.get(j), timestamp % 2 == 0);
+                        assertEquals(timestamp % 2 == 0, result.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(result.get(j), (timestamp + 2) * 1000);
+                        assertEquals((timestamp + 2) * 1000, result.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals((double) result.get(j), (4 + (END_TIME - timestamp) + 0.01) * 999, delta);
+                        assertEquals((4 + (END_TIME - timestamp) + 0.01) * 999, (double) result.get(j), delta);
                         break;
                     case "sg1.d1.s1":
                     case "sg1.d3.s3":
@@ -417,19 +455,19 @@ public class IoTDBSessionDataTypeTest {
         SessionAggregateQueryDataSet avgDataSet = session.aggregateQuery(aggrPaths, START_TIME, END_TIME + 1, AggregateType.AVG);
         List<String> avgResPaths = avgDataSet.getPaths();
         Object[] avgResult = avgDataSet.getValues();
-        assertEquals(avgResPaths.size(), aggrPaths.size());
-        assertEquals(avgDataSet.getValues().length, aggrPaths.size());
+        assertEquals(aggrPaths.size(), avgResPaths.size());
+        assertEquals(aggrPaths.size(), avgDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             switch (avgResPaths.get(i)) {
                 case "sg1.d2.s2":
-                    assertEquals(avgResult[i], (START_TIME + END_TIME) * 500.0 + 2000);
+                    assertEquals((START_TIME + END_TIME) * 500.0 + 2000, avgResult[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals((double) avgResult[i], (START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, delta * 1000);
+                    assertEquals((START_TIME + END_TIME) * 999 / 2.0 + 4.01 * 999, (double) avgResult[i], delta * 1000);
                     break;
                 case "sg1.d1.s1":
                 case "sg1.d3.s3":
-                    assertEquals(new String((byte[]) avgResult[i]), "null");
+                    assertEquals("null", new String((byte[]) avgResult[i]));
                     break;
                 default:
                     fail();

--- a/test/src/test/java/cn/edu/tsinghua/iginx/integration/IoTDBSessionIT.java
+++ b/test/src/test/java/cn/edu/tsinghua/iginx/integration/IoTDBSessionIT.java
@@ -7,10 +7,18 @@ import cn.edu.tsinghua.iginx.session.SessionAggregateQueryDataSet;
 import cn.edu.tsinghua.iginx.session.SessionQueryDataSet;
 import cn.edu.tsinghua.iginx.thrift.AggregateType;
 import cn.edu.tsinghua.iginx.thrift.DataType;
+import org.apache.iotdb.rpc.IoTDBConnectionException;
+import org.apache.iotdb.rpc.StatementExecutionException;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZKUtil;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +31,7 @@ import static org.junit.Assert.fail;
 
 public class IoTDBSessionIT {
 
+    private static final Logger logger = LoggerFactory.getLogger(IoTDBSessionIT.class);
     private static final String DATABASE_NAME = "sg1";
     private static final String COLUMN_D1_S1 = "sg1.d1.s1";
     private static final String COLUMN_D2_S2 = "sg1.d2.s2";
@@ -100,8 +109,6 @@ public class IoTDBSessionIT {
             //      session.createDatabase(DATABASE_NAME);
             addColumns();
             insertRecords();
-            //TODO remove this line when the new iotdb release version fix this bug
-            Thread.sleep(10000);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -109,8 +116,39 @@ public class IoTDBSessionIT {
 
     @After
     public void tearDown() throws ExecutionException, SessionException {
-        session.dropDatabase(DATABASE_NAME);
-        session.closeSession();
+        // delete metadata from ZooKeeper
+        ZooKeeper zk = null;
+        try {
+            zk = new ZooKeeper("127.0.0.1:2181", 5000, null);
+            ZKUtil.deleteRecursive(zk, "/iginx");
+            ZKUtil.deleteRecursive(zk, "/storage");
+            ZKUtil.deleteRecursive(zk, "/unit");
+            ZKUtil.deleteRecursive(zk, "/lock");
+            ZKUtil.deleteRecursive(zk, "/fragment");
+        } catch (IOException | InterruptedException | KeeperException e) {
+            logger.error(e.getMessage());
+        }
+
+        // delete data from IoTDB
+        org.apache.iotdb.session.Session iotdbSession = null;
+        try {
+            iotdbSession = new org.apache.iotdb.session.Session("127.0.0.1", 6667, "root", "root");
+            iotdbSession.open(false);
+            iotdbSession.executeNonQueryStatement("DELETE TIMESERIES root.*");
+        } catch (IoTDBConnectionException | StatementExecutionException e) {
+            logger.error(e.getMessage());
+        }
+
+        // close session
+        try {
+            iotdbSession.close();
+            if (zk != null) {
+                zk.close();
+            }
+            session.closeSession();
+        } catch (InterruptedException | IoTDBConnectionException e) {
+            logger.error(e.getMessage());
+        }
     }
 
     @Test
@@ -118,26 +156,26 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dataSet = session.queryData(paths, START_TIME, END_TIME + 1);
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(4, resPaths.size());
+        assertEquals(TIME_PERIOD, len);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 switch (resPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(result.get(j), timestamp);
+                        assertEquals(timestamp, result.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(result.get(j), timestamp + 1);
+                        assertEquals(timestamp + 1, result.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(result.get(j), timestamp + 2);
+                        assertEquals(timestamp + 2, result.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(result.get(j), timestamp + 3);
+                        assertEquals(timestamp + 3, result.get(j));
                         break;
                     default:
                         fail();
@@ -164,27 +202,27 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dataSet = session.valueFilterQuery(paths, START_TIME, END_TIME, booleanExpression);
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, TIME_PERIOD - (s1 - START_TIME + 1) - (END_TIME - s2 + 2) - (s3 - s4 + 2));
+        assertEquals(4, resPaths.size());
+        assertEquals(TIME_PERIOD - (s1 - START_TIME + 1) - (END_TIME - s2 + 2) - (s3 - s4 + 2), len);
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 switch (resPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(result.get(j), timestamp);
+                        assertEquals(timestamp, result.get(j));
                         assertTrue(timestamp > s1);
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(result.get(j), timestamp + 1);
+                        assertEquals(timestamp + 1, result.get(j));
                         assertTrue(timestamp + 1 < s2);
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(result.get(j), timestamp + 2);
+                        assertEquals(timestamp + 2, result.get(j));
                         assertTrue(timestamp + 2 > s3 || timestamp + 3 < s4);
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(result.get(j), timestamp + 3);
+                        assertEquals(timestamp + 3, result.get(j));
                         assertTrue(timestamp + 2 > s3 || timestamp + 3 < s4);
                         break;
                     default:
@@ -204,23 +242,23 @@ public class IoTDBSessionIT {
         int len = maxDataSet.getTimestamps().length;
         List<String> resPaths = maxDataSet.getPaths();
         Object[] result = maxDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, 4);
-        assertEquals(maxDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, len);
+        assertEquals(4, maxDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
-            assertEquals(maxDataSet.getTimestamps()[i], -1);
+            assertEquals(-1, maxDataSet.getTimestamps()[i]);
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(result[i], END_TIME);
+                    assertEquals(END_TIME, result[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(result[i], END_TIME + 1);
+                    assertEquals(END_TIME + 1, result[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(result[i], END_TIME + 2);
+                    assertEquals(END_TIME + 2, result[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(result[i], END_TIME + 3);
+                    assertEquals(END_TIME + 3, result[i]);
                     break;
                 default:
                     fail();
@@ -231,28 +269,28 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.MAX, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long maxNum = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(dsResult.get(j), maxNum);
+                        assertEquals(maxNum, dsResult.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(dsResult.get(j), maxNum + 1);
+                        assertEquals(maxNum + 1, dsResult.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(dsResult.get(j), maxNum + 2);
+                        assertEquals(maxNum + 2, dsResult.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(dsResult.get(j), maxNum + 3);
+                        assertEquals(maxNum + 3, dsResult.get(j));
                         break;
                     default:
                         fail();
@@ -270,23 +308,23 @@ public class IoTDBSessionIT {
         int len = minDataSet.getTimestamps().length;
         List<String> resPaths = minDataSet.getPaths();
         Object[] result = minDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, 4);
-        assertEquals(minDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, len);
+        assertEquals(4, minDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
-            assertEquals(minDataSet.getTimestamps()[i], -1);
+            assertEquals(-1, minDataSet.getTimestamps()[i]);
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(result[i], START_TIME);
+                    assertEquals(START_TIME, result[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(result[i], START_TIME + 1);
+                    assertEquals(START_TIME + 1, result[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(result[i], START_TIME + 2);
+                    assertEquals(START_TIME + 2, result[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(result[i], START_TIME + 3);
+                    assertEquals(START_TIME + 3, result[i]);
                     break;
                 default:
                     fail();
@@ -297,28 +335,28 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.MIN, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long minNum = START_TIME + i * PRECISION;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(dsResult.get(j), minNum);
+                        assertEquals(minNum, dsResult.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(dsResult.get(j), minNum + 1);
+                        assertEquals(minNum + 1, dsResult.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(dsResult.get(j), minNum + 2);
+                        assertEquals(minNum + 2, dsResult.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(dsResult.get(j), minNum + 3);
+                        assertEquals(minNum + 3, dsResult.get(j));
                         break;
                     default:
                         fail();
@@ -336,23 +374,23 @@ public class IoTDBSessionIT {
         int len = firstDataSet.getTimestamps().length;
         List<String> resPaths = firstDataSet.getPaths();
         Object[] result = firstDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, 4);
-        assertEquals(firstDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, len);
+        assertEquals(4, firstDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
-            assertEquals(firstDataSet.getTimestamps()[i], -1);
+            assertEquals(-1, firstDataSet.getTimestamps()[i]);
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(result[i], START_TIME);
+                    assertEquals(START_TIME, result[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(result[i], START_TIME + 1);
+                    assertEquals(START_TIME + 1, result[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(result[i], START_TIME + 2);
+                    assertEquals(START_TIME + 2, result[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(result[i], START_TIME + 3);
+                    assertEquals(START_TIME + 3, result[i]);
                     break;
                 default:
                     fail();
@@ -363,28 +401,28 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.FIRST, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long firstNum = START_TIME + i * PRECISION;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(dsResult.get(j), firstNum);
+                        assertEquals(firstNum, dsResult.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(dsResult.get(j), firstNum + 1);
+                        assertEquals(firstNum + 1, dsResult.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(dsResult.get(j), firstNum + 2);
+                        assertEquals(firstNum + 2, dsResult.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(dsResult.get(j), firstNum + 3);
+                        assertEquals(firstNum + 3, dsResult.get(j));
                         break;
                     default:
                         fail();
@@ -402,23 +440,23 @@ public class IoTDBSessionIT {
         int len = lastDataSet.getTimestamps().length;
         List<String> resPaths = lastDataSet.getPaths();
         Object[] result = lastDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(len, 4);
-        assertEquals(lastDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, len);
+        assertEquals(4, lastDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
-            assertEquals(lastDataSet.getTimestamps()[i], -1);
+            assertEquals(-1, lastDataSet.getTimestamps()[i]);
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(result[i], END_TIME);
+                    assertEquals(END_TIME, result[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(result[i], END_TIME + 1);
+                    assertEquals(END_TIME + 1, result[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(result[i], END_TIME + 2);
+                    assertEquals(END_TIME + 2, result[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(result[i], END_TIME + 3);
+                    assertEquals(END_TIME + 3, result[i]);
                     break;
                 default:
                     fail();
@@ -429,27 +467,27 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.LAST, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long lastNum = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(dsResult.get(j), lastNum);
+                        assertEquals(lastNum, dsResult.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(dsResult.get(j), lastNum + 1);
+                        assertEquals(lastNum + 1, dsResult.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(dsResult.get(j), lastNum + 2);
+                        assertEquals(lastNum + 2, dsResult.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(dsResult.get(j), lastNum + 3);
+                        assertEquals(lastNum + 3, dsResult.get(j));
                         break;
                     default:
                         fail();
@@ -466,25 +504,25 @@ public class IoTDBSessionIT {
         assertNull(countDataSet.getTimestamps());
         List<String> resPaths = countDataSet.getPaths();
         Object[] result = countDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(countDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, countDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
-            assertEquals(result[i], TIME_PERIOD);
+            assertEquals(TIME_PERIOD, result[i]);
         }
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.COUNT, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long countNum = ((START_TIME + (i + 1) * PRECISION - 1) <= END_TIME) ? PRECISION : END_TIME - dsTimestamp + 1;
-                assertEquals(dsResult.get(j), countNum);
+                assertEquals(countNum, dsResult.get(j));
             }
         }
     }
@@ -495,22 +533,22 @@ public class IoTDBSessionIT {
         assertNull(sumDataSet.getTimestamps());
         List<String> resPaths = sumDataSet.getPaths();
         Object[] result = sumDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(sumDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, sumDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             double sum = (START_TIME + END_TIME) * TIME_PERIOD / 2.0;
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(result[i], sum);
+                    assertEquals(sum, result[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(result[i], sum + TIME_PERIOD);
+                    assertEquals(sum + TIME_PERIOD, result[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(result[i], sum + TIME_PERIOD * 2);
+                    assertEquals(sum + TIME_PERIOD * 2, result[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(result[i], sum + TIME_PERIOD * 3);
+                    assertEquals(sum + TIME_PERIOD * 3, result[i]);
                     break;
                 default:
                     fail();
@@ -521,29 +559,29 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.SUM, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long maxNum = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 double sum = (dsTimestamp + maxNum) * (maxNum - dsTimestamp + 1) / 2.0;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals(dsResult.get(j), sum);
+                        assertEquals(sum, dsResult.get(j));
                         break;
                     case "sg1.d2.s2":
-                        assertEquals(dsResult.get(j), sum + (maxNum - dsTimestamp + 1));
+                        assertEquals(sum + (maxNum - dsTimestamp + 1), dsResult.get(j));
                         break;
                     case "sg1.d3.s3":
-                        assertEquals(dsResult.get(j), sum + 2 * (maxNum - dsTimestamp + 1));
+                        assertEquals(sum + 2 * (maxNum - dsTimestamp + 1), dsResult.get(j));
                         break;
                     case "sg1.d4.s4":
-                        assertEquals(dsResult.get(j), sum + 3 * (maxNum - dsTimestamp + 1));
+                        assertEquals(sum + 3 * (maxNum - dsTimestamp + 1), dsResult.get(j));
                         break;
                     default:
                         fail();
@@ -561,22 +599,22 @@ public class IoTDBSessionIT {
         assertNull(avgDataSet.getTimestamps());
         List<String> resPaths = avgDataSet.getPaths();
         Object[] result = avgDataSet.getValues();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(avgDataSet.getValues().length, 4);
+        assertEquals(4, resPaths.size());
+        assertEquals(4, avgDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             double avg = (START_TIME + END_TIME) / 2.0;
             switch (resPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals((double) result[i], avg, delta);
+                    assertEquals(avg, (double) result[i], delta);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals((double) result[i], avg + 1, delta);
+                    assertEquals(avg + 1, (double) result[i], delta);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals((double) result[i], avg + 2, delta);
+                    assertEquals(avg + 2, (double) result[i], delta);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals((double) result[i], avg + 3, delta);
+                    assertEquals(avg + 3, (double) result[i], delta);
                     break;
                 default:
                     fail();
@@ -587,29 +625,29 @@ public class IoTDBSessionIT {
         SessionQueryDataSet dsDataSet = session.downsampleQuery(paths, START_TIME, END_TIME + 1, AggregateType.AVG, PRECISION);
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
-        assertEquals(dsResPaths.size(), 4);
+        assertEquals(4, dsResPaths.size());
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 long maxNum = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 double avg = (dsTimestamp + maxNum) / 2.0;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d1.s1":
-                        assertEquals((double) dsResult.get(j), avg, delta);
+                        assertEquals(avg, (double) dsResult.get(j), delta);
                         break;
                     case "sg1.d2.s2":
-                        assertEquals((double) dsResult.get(j), avg + 1, delta);
+                        assertEquals(avg + 1, (double) dsResult.get(j), delta);
                         break;
                     case "sg1.d3.s3":
-                        assertEquals((double) dsResult.get(j), avg + 2, delta);
+                        assertEquals(avg + 2, (double) dsResult.get(j), delta);
                         break;
                     case "sg1.d4.s4":
-                        assertEquals((double) dsResult.get(j), avg + 3, delta);
+                        assertEquals(avg + 3, (double) dsResult.get(j), delta);
                         break;
                     default:
                         fail();
@@ -637,17 +675,17 @@ public class IoTDBSessionIT {
 
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(resPaths.size(), 4);
-        assertEquals(dataSet.getTimestamps().length, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(4, resPaths.size());
+        assertEquals(TIME_PERIOD, dataSet.getTimestamps().length);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             if (delStartTime <= timestamp && timestamp <= delEndTime) {
                 for (int j = 0; j < 4; j++) {
                     if ("sg1.d2.s2".equals(resPaths.get(j))) {
-                        assertEquals(result.get(j), timestamp + 1);
+                        assertEquals(timestamp + 1, result.get(j));
                     } else {
                         assertNull(result.get(j));
                     }
@@ -656,16 +694,16 @@ public class IoTDBSessionIT {
                 for (int j = 0; j < 4; j++) {
                     switch (resPaths.get(j)) {
                         case "sg1.d1.s1":
-                            assertEquals(result.get(j), timestamp);
+                            assertEquals(timestamp, result.get(j));
                             break;
                         case "sg1.d2.s2":
-                            assertEquals(result.get(j), timestamp + 1);
+                            assertEquals(timestamp + 1, result.get(j));
                             break;
                         case "sg1.d3.s3":
-                            assertEquals(result.get(j), timestamp + 2);
+                            assertEquals(timestamp + 2, result.get(j));
                             break;
                         case "sg1.d4.s4":
-                            assertEquals(result.get(j), timestamp + 3);
+                            assertEquals(timestamp + 3, result.get(j));
                             break;
                         default:
                             fail();
@@ -679,24 +717,24 @@ public class IoTDBSessionIT {
         SessionAggregateQueryDataSet avgDataSet = session.aggregateQuery(paths, START_TIME, END_TIME + 1, AggregateType.AVG);
         List<String> avgResPaths = avgDataSet.getPaths();
         Object[] avgResult = avgDataSet.getValues();
-        assertEquals(avgResPaths.size(), 4);
-        assertEquals(avgDataSet.getValues().length, 4);
+        assertEquals(4, avgResPaths.size());
+        assertEquals(4, avgDataSet.getValues().length);
 
         for (int i = 0; i < 4; i++) {
             double avg = ((START_TIME + END_TIME) * TIME_PERIOD / 2.0
                     - (delStartTime + delEndTime) * delTimePeriod / 2.0) / (TIME_PERIOD - delTimePeriod);
             switch (avgResPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(avgResult[i], avg);
+                    assertEquals(avg, avgResult[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(avgResult[i], (START_TIME + END_TIME) / 2.0 + 1);
+                    assertEquals((START_TIME + END_TIME) / 2.0 + 1, avgResult[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(avgResult[i], avg + 2);
+                    assertEquals(avg + 2, avgResult[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(avgResult[i], avg + 3);
+                    assertEquals(avg + 3, avgResult[i]);
                     break;
                 default:
                     fail();
@@ -708,23 +746,23 @@ public class IoTDBSessionIT {
         SessionAggregateQueryDataSet maxDataSet = session.aggregateQuery(paths, START_TIME, END_TIME + 1, AggregateType.MAX);
         List<String> maxResPaths = maxDataSet.getPaths();
         Object[] maxResult = maxDataSet.getValues();
-        assertEquals(maxResPaths.size(), 4);
-        assertEquals(maxDataSet.getValues().length, 4);
+        assertEquals(4, maxResPaths.size());
+        assertEquals(4, maxDataSet.getValues().length);
 
         for (int i = 0; i < 4; i++) {
             long max = (delEndTime >= END_TIME) ? delStartTime - 1 : END_TIME;
             switch (maxResPaths.get(i)) {
                 case "sg1.d1.s1":
-                    assertEquals(maxResult[i], max);
+                    assertEquals(max, maxResult[i]);
                     break;
                 case "sg1.d2.s2":
-                    assertEquals(maxResult[i], END_TIME + 1);
+                    assertEquals(END_TIME + 1, maxResult[i]);
                     break;
                 case "sg1.d3.s3":
-                    assertEquals(maxResult[i], max + 2);
+                    assertEquals(max + 2, maxResult[i]);
                     break;
                 case "sg1.d4.s4":
-                    assertEquals(maxResult[i], max + 3);
+                    assertEquals(max + 3, maxResult[i]);
                     break;
                 default:
                     fail();
@@ -737,50 +775,50 @@ public class IoTDBSessionIT {
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsStartTime = dsDataSet.getTimestamps()[i];
-            assertEquals(dsStartTime, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsStartTime);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < dsResPaths.size(); j++) {
                 long dsEndTime = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 double avg = (dsStartTime + dsEndTime) / 2.0;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d2.s2":
-                        assertEquals((double) dsResult.get(j), avg + 1, delta);
+                        assertEquals(avg + 1, (double) dsResult.get(j), delta);
                         break;
                     case "sg1.d1.s1":
                         if (dsStartTime > delEndTime || dsEndTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), avg, delta);
+                            assertEquals(avg, (double) dsResult.get(j), delta);
                         } else if (dsStartTime >= delStartTime && dsEndTime <= delEndTime) {
                             assertNull(dsResult.get(j));
                         } else if (dsStartTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), (dsStartTime + delStartTime - 1) / 2.0, delta);
+                            assertEquals((dsStartTime + delStartTime - 1) / 2.0, (double) dsResult.get(j), delta);
                         } else {
-                            assertEquals((double) dsResult.get(j), (dsEndTime + delEndTime + 1) / 2.0, delta);
+                            assertEquals((dsEndTime + delEndTime + 1) / 2.0, (double) dsResult.get(j), delta);
                         }
                         break;
                     case "sg1.d3.s3":
                         if (dsStartTime > delEndTime || dsEndTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), avg + 2, delta);
+                            assertEquals(avg + 2, (double) dsResult.get(j), delta);
                         } else if (dsStartTime >= delStartTime && dsEndTime <= delEndTime) {
                             assertNull(dsResult.get(j));
                         } else if (dsStartTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), (dsStartTime + delStartTime - 1) / 2.0 + 2, delta);
+                            assertEquals((dsStartTime + delStartTime - 1) / 2.0 + 2, (double) dsResult.get(j), delta);
                         } else {
-                            assertEquals((double) dsResult.get(j), (dsEndTime + delEndTime + 1) / 2.0 + 2, delta);
+                            assertEquals((dsEndTime + delEndTime + 1) / 2.0 + 2, (double) dsResult.get(j), delta);
                         }
                         break;
                     case "sg1.d4.s4":
                         if (dsStartTime > delEndTime || dsEndTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), avg + 3, delta);
+                            assertEquals(avg + 3, (double) dsResult.get(j), delta);
                         } else if (dsStartTime >= delStartTime && dsEndTime <= delEndTime) {
                             assertNull(dsResult.get(j));
                         } else if (dsStartTime < delStartTime) {
-                            assertEquals((double) dsResult.get(j), (dsStartTime + delStartTime - 1) / 2.0 + 3, delta);
+                            assertEquals((dsStartTime + delStartTime - 1) / 2.0 + 3, (double) dsResult.get(j), delta);
                         } else {
-                            assertEquals((double) dsResult.get(j), (dsEndTime + delEndTime + 1) / 2.0 + 3, delta);
+                            assertEquals((dsEndTime + delEndTime + 1) / 2.0 + 3, (double) dsResult.get(j), delta);
                         }
                         break;
                     default:
@@ -805,15 +843,15 @@ public class IoTDBSessionIT {
 
         int len = dataSet.getTimestamps().length;
         List<String> resPaths = dataSet.getPaths();
-        assertEquals(dataSet.getTimestamps().length, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(TIME_PERIOD, dataSet.getTimestamps().length);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 if ("sg1.d2.s2".equals(resPaths.get(j))) {
-                    assertEquals(result.get(j), timestamp + 1);
+                    assertEquals(timestamp + 1, result.get(j));
                 } else {
                     assertNull(result.get(j));
                 }
@@ -826,14 +864,14 @@ public class IoTDBSessionIT {
         SessionQueryDataSet vfDataSet = session.valueFilterQuery(paths, START_TIME, END_TIME, booleanExpression);
         int vflen = vfDataSet.getTimestamps().length;
         List<String> vfResPaths = vfDataSet.getPaths();
-        assertEquals(vfDataSet.getTimestamps().length, TIME_PERIOD + START_TIME - vftime - 1);
+        assertEquals(TIME_PERIOD + START_TIME - vftime - 1, vfDataSet.getTimestamps().length);
         for (int i = 0; i < vflen; i++) {
             long timestamp = vfDataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + vftime);
+            assertEquals(i + vftime, timestamp);
             List<Object> result = vfDataSet.getValues().get(i);
             for (int j = 0; j < 4; j++) {
                 if ("sg1.d2.s2".equals(vfResPaths.get(j))) {
-                    assertEquals(result.get(j), timestamp + 1);
+                    assertEquals(timestamp + 1, result.get(j));
                 } else {
                     assertNull(result.get(j));
                 }
@@ -844,17 +882,17 @@ public class IoTDBSessionIT {
         SessionAggregateQueryDataSet avgDataSet = session.aggregateQuery(paths, START_TIME, END_TIME + 1, AggregateType.AVG);
         List<String> avgResPaths = avgDataSet.getPaths();
         Object[] avgResult = avgDataSet.getValues();
-        assertEquals(avgResPaths.size(), 4);
-        assertEquals(avgDataSet.getValues().length, 4);
+        assertEquals(4, avgResPaths.size());
+        assertEquals(4, avgDataSet.getValues().length);
         for (int i = 0; i < 4; i++) {
             switch (avgResPaths.get(i)) {
                 case "sg1.d2.s2":
-                    assertEquals(avgResult[i], (START_TIME + END_TIME) / 2.0 + 1);
+                    assertEquals((START_TIME + END_TIME) / 2.0 + 1, avgResult[i]);
                     break;
                 case "sg1.d1.s1":
                 case "sg1.d3.s3":
                 case "sg1.d4.s4":
-                    assertEquals(new String((byte[]) avgResult[i]), "null");
+                    assertEquals("null", new String((byte[]) avgResult[i]));
                     break;
                 default:
                     fail();
@@ -866,18 +904,18 @@ public class IoTDBSessionIT {
         int dsLen = dsDataSet.getTimestamps().length;
         List<String> dsResPaths = dsDataSet.getPaths();
         long factLen = (TIME_PERIOD / PRECISION) + ((TIME_PERIOD % PRECISION == 0) ? 0 : 1);
-        assertEquals(dsLen, factLen);
-        assertEquals(dsDataSet.getValues().size(), factLen);
+        assertEquals(factLen, dsLen);
+        assertEquals(factLen, dsDataSet.getValues().size());
         for (int i = 0; i < dsLen; i++) {
             long dsTimestamp = dsDataSet.getTimestamps()[i];
-            assertEquals(dsTimestamp, START_TIME + i * PRECISION);
+            assertEquals(START_TIME + i * PRECISION, dsTimestamp);
             List<Object> dsResult = dsDataSet.getValues().get(i);
             for (int j = 0; j < dsResPaths.size(); j++) {
                 long maxNum = Math.min((START_TIME + (i + 1) * PRECISION - 1), END_TIME);
                 double avg = (dsTimestamp + maxNum) / 2.0;
                 switch (dsResPaths.get(j)) {
                     case "sg1.d2.s2":
-                        assertEquals((double) dsResult.get(j), avg + 1, delta);
+                        assertEquals(avg + 1, (double) dsResult.get(j), delta);
                         break;
                     case "sg1.d1.s1":
                     case "sg1.d3.s3":
@@ -896,9 +934,9 @@ public class IoTDBSessionIT {
     public void deleteAllColumnsTest() throws SessionException, ExecutionException {
         session.deleteColumns(paths);
         SessionQueryDataSet dataSet = session.queryData(paths, START_TIME, END_TIME + 1);
-        assertEquals(dataSet.getPaths().size(), 0);
-        assertEquals(dataSet.getTimestamps().length, 0);
-        assertEquals(dataSet.getValues().size(), 0);
+        assertEquals(0, dataSet.getPaths().size());
+        assertEquals(0, dataSet.getTimestamps().length);
+        assertEquals(0, dataSet.getValues().size());
     }
 
     @Test
@@ -910,15 +948,15 @@ public class IoTDBSessionIT {
         session.deleteColumns(delPaths);
         SessionQueryDataSet dataSet = session.queryData(paths, START_TIME, END_TIME + 1);
         int len = dataSet.getTimestamps().length;
-        assertEquals(dataSet.getPaths().size(), 1);
-        assertEquals(dataSet.getPaths().get(0), "sg1.d2.s2");
-        assertEquals(len, TIME_PERIOD);
-        assertEquals(dataSet.getValues().size(), TIME_PERIOD);
+        assertEquals(1, dataSet.getPaths().size());
+        assertEquals("sg1.d2.s2", dataSet.getPaths().get(0));
+        assertEquals(TIME_PERIOD, len);
+        assertEquals(TIME_PERIOD, dataSet.getValues().size());
         for (int i = 0; i < len; i++) {
             long timestamp = dataSet.getTimestamps()[i];
-            assertEquals(timestamp, i + START_TIME);
+            assertEquals(i + START_TIME, timestamp);
             List<Object> result = dataSet.getValues().get(i);
-            assertEquals(result.get(0), timestamp + 1);
+            assertEquals(timestamp + 1, result.get(0));
         }
     }
 }


### PR DESCRIPTION
修复了IT中存在的两个问题：
1. 每个测试样例执行结束之后，没有将ZooKeeper的元数据和IoTDB的数据清空。
2. assert语句中的expected和actual写反了。