### PR TITLE
Inefficient Usages of Java Collections

### DIFF
--- a/core/src/main/java/cn/edu/tsinghua/iginx/rest/insert/DataPointsParser.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/rest/insert/DataPointsParser.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Reader;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class DataPointsParser {
     private final IMetaManager metaManager = DefaultMetaManager.getInstance();
     private Reader inputStream = null;
     private ObjectMapper mapper = new ObjectMapper();
-    private List<Metric> metricList = new ArrayList<>();
+    private List<Metric> metricList = new LinkedList<>();
     private RestSession session = new RestSession();
 
     public DataPointsParser() {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/Query.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/Query.java
@@ -19,6 +19,7 @@
 package cn.edu.tsinghua.iginx.rest.query;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 public class Query {
@@ -26,7 +27,7 @@ public class Query {
     private Long endAbsolute;
     private Long cacheTime;
     private String timeZone;
-    private List<QueryMetric> queryMetrics = new ArrayList<>();
+    private List<QueryMetric> queryMetrics = new LinkedList<>();
 
     public List<QueryMetric> getQueryMetrics() {
         return queryMetrics;

--- a/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/QueryMetric.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/QueryMetric.java
@@ -21,6 +21,7 @@ package cn.edu.tsinghua.iginx.rest.query;
 import cn.edu.tsinghua.iginx.rest.query.aggregator.QueryAggregator;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -29,7 +30,7 @@ public class QueryMetric {
     private String name;
     private Long limit;
     private Map<String, List<String>> tags = new TreeMap();
-    private List<QueryAggregator> aggregators = new ArrayList<>();
+    private List<QueryAggregator> aggregators = new LinkedList<>();
     private Boolean annotation = false;
     private AnnotationLimit annotationLimit;
 

--- a/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/aggregator/QueryAggregatorSaveAs.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/aggregator/QueryAggregatorSaveAs.java
@@ -25,7 +25,7 @@ import cn.edu.tsinghua.iginx.rest.query.QueryResultDataset;
 import cn.edu.tsinghua.iginx.session.SessionQueryDataSet;
 
 import java.util.ArrayList;
-import java.util.LinkedList
+import java.util.LinkedList;
 import java.util.List;
 
 public class QueryAggregatorSaveAs extends QueryAggregator {

--- a/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/aggregator/QueryAggregatorSaveAs.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/rest/query/aggregator/QueryAggregatorSaveAs.java
@@ -25,6 +25,7 @@ import cn.edu.tsinghua.iginx.rest.query.QueryResultDataset;
 import cn.edu.tsinghua.iginx.session.SessionQueryDataSet;
 
 import java.util.ArrayList;
+import java.util.LinkedList
 import java.util.List;
 
 public class QueryAggregatorSaveAs extends QueryAggregator {
@@ -35,7 +36,7 @@ public class QueryAggregatorSaveAs extends QueryAggregator {
     @Override
     public QueryResultDataset doAggregate(RestSession session, List<String> paths, long startTimestamp, long endTimestamp) {
         DataPointsParser parser = new DataPointsParser();
-        List<Metric> metrics = new ArrayList<>();
+        List<Metric> metrics = new LinkedList<>();
         Metric ins = new Metric();
         String name = paths.get(0).split("\\.")[paths.get(0).split("\\.").length - 1];
         ins.setName(getMetric_name());

--- a/core/src/main/java/cn/edu/tsinghua/iginx/sql/operator/SelectOperator.java
+++ b/core/src/main/java/cn/edu/tsinghua/iginx/sql/operator/SelectOperator.java
@@ -16,6 +16,7 @@ import cn.edu.tsinghua.iginx.utils.Pair;
 import cn.edu.tsinghua.iginx.utils.RpcUtils;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class SelectOperator extends Operator {
     public SelectOperator() {
         this.operatorType = OperatorType.SELECT;
         this.queryType = QueryType.Unknown;
-        selectedFuncsAndPaths = new ArrayList<>();
+        selectedFuncsAndPaths = new LinkedList<>();
         funcTypeSet = new HashSet<>();
         fromPath = "";
         startTime = Long.MIN_VALUE;

--- a/jdbc/src/main/java/cn/edu/tsinghua/iginx/jdbc/IginXPreparedStatement.java
+++ b/jdbc/src/main/java/cn/edu/tsinghua/iginx/jdbc/IginXPreparedStatement.java
@@ -13,7 +13,7 @@ import java.util.*;
 public class IginXPreparedStatement extends IginXStatement implements PreparedStatement {
 
     private String sql;
-    private final Map<Integer, String> params = new LinkedHashMap<>();
+    private final Map<Integer, String> params = new HashMap<>();
 
     public IginXPreparedStatement(IginXConnection connection, Session session, String sql) {
         super(connection, session);

--- a/session/src/main/java/cn/edu/tsinghua/iginx/session/LastQueryDataSet.java
+++ b/session/src/main/java/cn/edu/tsinghua/iginx/session/LastQueryDataSet.java
@@ -22,6 +22,7 @@ import cn.edu.tsinghua.iginx.thrift.DataType;
 import cn.edu.tsinghua.iginx.thrift.LastQueryResp;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import static cn.edu.tsinghua.iginx.utils.ByteUtils.getLongArrayFromByteBuffer;
@@ -36,7 +37,7 @@ public class LastQueryDataSet {
     }
 
     LastQueryDataSet(LastQueryResp resp) {
-        points = new ArrayList<>();
+        points = new LinkedList<>();
         List<String> paths = resp.getPaths();
         List<DataType> dataTypes = resp.getDataTypeList();
         long[] timestamps = getLongArrayFromByteBuffer(resp.timestamps);


### PR DESCRIPTION
Hi,

We find that there are several inefficient usages of Java Collections:

1. There is no iteration occurring upon a LinkedHashMap, thus the insertion order does not matter. We recommend replacing it with a HashMap.
2. ArrayList is inserted before an iteration, while multiple memory reallocation might occur when the size of the list exceeds its capacity. We recommend replacing it with a LinkedList.

We discovered the above inefficient usages of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto