### PR TITLE
Fix thrift url

### DIFF
--- a/maven-repo/cn/edu/tsinghua/iginx-thrift/0.3.0/iginx-thrift-0.3.0.pom
+++ b/maven-repo/cn/edu/tsinghua/iginx-thrift/0.3.0/iginx-thrift-0.3.0.pom
@@ -195,7 +195,7 @@
             </activation>
             <properties>
                 <thrift.download-url>
-                    http://artfiles.org/apache.org/thrift/${thrift.version}/thrift-${thrift.version}.exe
+                    http://archive.apache.org/dist/thrift/${thrift.version}/thrift-${thrift.version}.exe
                 </thrift.download-url>
                 <thrift.executable>thrift-${thrift.version}-win-x86_64.exe</thrift.executable>
                 <thrift.skip-making-executable>true</thrift.skip-making-executable>

--- a/thrift/pom.xml
+++ b/thrift/pom.xml
@@ -224,7 +224,7 @@
             </activation>
             <properties>
                 <thrift.download-url>
-                    http://artfiles.org/apache.org/thrift/${thrift.version}/thrift-${thrift.version}.exe
+                    http://archive.apache.org/dist/thrift/${thrift.version}/thrift-${thrift.version}.exe
                 </thrift.download-url>
                 <thrift.executable>thrift-${thrift.version}-win-x86_64.exe</thrift.executable>
                 <thrift.skip-making-executable>true</thrift.skip-making-executable>


### PR DESCRIPTION
The current using thrift.download-url  https://artfiles.org/apache.org/thrift/  now only contains the latest thrift version, so a new user will get a 404 Not found error while installing by maven. The website http://archive.apache.org/dist/thrift/ can get the older versions.